### PR TITLE
Add optional `serde` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intervals-general"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Scott Moeller <electronjoe@gmail.com>"]
 description = """
 intervals-general is a crate enabling general representation of and
@@ -13,14 +13,15 @@ repository = "https://github.com/electronjoe/intervals-general"
 readme = "README.md"
 keywords = ["intervals", "interval", "math", "units", "measurement"]
 categories = ["science", "data-structures"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [badges]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-itertools = "0.8.0"
+itertools = "0.13.0"
+serde = { version = "1.0.203", features = ["derive"], optional = true }
 
 [dev-dependencies]
 criterion = "0.2"
@@ -36,4 +37,4 @@ name = "interval_operations"
 harness = false
 
 [profile.bench]
-lto = true  # Critical for performance (87% reduction of e.g. intersect)
+lto = true # Critical for performance (87% reduction of e.g. intersect)

--- a/src/bound_pair.rs
+++ b/src/bound_pair.rs
@@ -1,13 +1,37 @@
-/// A BoundPair represents valid left and right Interval bounds
-///
-/// For Intervals containing finite bounds, the BoundPair construction
-/// ensures well-formed left and right bounds prior to Interval enum
-/// construction (e.g. left < right).
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub struct BoundPair<T> {
-    pub(crate) left: T,
-    pub(crate) right: T,
+#[cfg(not(feature = "serde"))]
+mod without_serde {
+    /// A BoundPair represents valid left and right Interval bounds
+    ///
+    /// For Intervals containing finite bounds, the BoundPair construction
+    /// ensures well-formed left and right bounds prior to Interval enum
+    /// construction (e.g. left < right).
+    #[derive(Debug, Copy, Clone, PartialEq)]
+    pub struct BoundPair<T> {
+        pub(crate) left: T,
+        pub(crate) right: T,
+    }
 }
+
+#[cfg(feature = "serde")]
+mod with_serde {
+    use serde::{Deserialize, Serialize};
+
+    /// A BoundPair represents valid left and right Interval bounds
+    ///
+    /// For Intervals containing finite bounds, the BoundPair construction
+    /// ensures well-formed left and right bounds prior to Interval enum
+    /// construction (e.g. left < right).
+    #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+    pub struct BoundPair<T> {
+        pub(crate) left: T,
+        pub(crate) right: T,
+    }
+}
+
+#[cfg(feature = "serde")]
+pub use with_serde::BoundPair;
+#[cfg(not(feature = "serde"))]
+pub use without_serde::BoundPair;
 
 impl<T> BoundPair<T>
 where

--- a/src/interval.rs
+++ b/src/interval.rs
@@ -2,47 +2,104 @@ use crate::bound_pair::BoundPair;
 use itertools::Either;
 use std::cmp::Ordering;
 
-/// Interval enum capable of general interval representation
-///
-/// Where applicable, using lower bound `a` and upper bound `b`.  An Interval taxonomy was pulled from [proofwiki](https://proofwiki.org/wiki/Definition:Real_Interval_Types).
-///
-/// * Closed -> `[a, b]`
-/// * Open -> `(a,b)`
-/// * LeftHalfOpen -> `(a, b]`
-/// * RightHalfOpen -> `[a, b)`
-/// * UnboundedClosedRight -> `(-inf, a]`
-/// * UnboundedOpenRight -> `(-inf, a)`
-/// * UnboundedClosedLeft -> `[a, inf)`
-/// * UnboundedOpenLeft -> `(a, inf)`
-/// * Singeleton -> `[a]`
-/// * Unbounded -> `(-inf, inf)`
-/// * Empty
-///
-/// # Examples
-///
-/// ```
-/// use intervals_general::bound_pair::BoundPair;
-/// use intervals_general::interval::Interval;
-/// # fn main() -> std::result::Result<(), String> {
-/// let bounds = BoundPair::new(1.0, 2.0).ok_or("invalid BoundPair")?;
-/// let right_half_open = Interval::RightHalfOpen { bound_pair: bounds }; // [1.0, 2.0)
-/// # Ok(())
-/// # }
-/// ```
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub enum Interval<T> {
-    Closed { bound_pair: BoundPair<T> },
-    Open { bound_pair: BoundPair<T> },
-    LeftHalfOpen { bound_pair: BoundPair<T> },
-    RightHalfOpen { bound_pair: BoundPair<T> },
-    UnboundedClosedRight { right: T },
-    UnboundedOpenRight { right: T },
-    UnboundedClosedLeft { left: T },
-    UnboundedOpenLeft { left: T },
-    Singleton { at: T },
-    Unbounded,
-    Empty,
+#[cfg(not(feature = "serde"))]
+mod without_serde {
+    use crate::bound_pair::BoundPair;
+    /// Interval enum capable of general interval representation
+    ///
+    /// Where applicable, using lower bound `a` and upper bound `b`.  An Interval taxonomy was pulled from [proofwiki](https://proofwiki.org/wiki/Definition:Real_Interval_Types).
+    ///
+    /// * Closed -> `[a, b]`
+    /// * Open -> `(a,b)`
+    /// * LeftHalfOpen -> `(a, b]`
+    /// * RightHalfOpen -> `[a, b)`
+    /// * UnboundedClosedRight -> `(-inf, a]`
+    /// * UnboundedOpenRight -> `(-inf, a)`
+    /// * UnboundedClosedLeft -> `[a, inf)`
+    /// * UnboundedOpenLeft -> `(a, inf)`
+    /// * Singeleton -> `[a]`
+    /// * Unbounded -> `(-inf, inf)`
+    /// * Empty
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use intervals_general::bound_pair::BoundPair;
+    /// use intervals_general::interval::Interval;
+    /// # fn main() -> std::result::Result<(), String> {
+    /// let bounds = BoundPair::new(1.0, 2.0).ok_or("invalid BoundPair")?;
+    /// let right_half_open = Interval::RightHalfOpen { bound_pair: bounds }; // [1.0, 2.0)
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[derive(Debug, Copy, Clone, PartialEq)]
+    pub enum Interval<T> {
+        Closed { bound_pair: BoundPair<T> },
+        Open { bound_pair: BoundPair<T> },
+        LeftHalfOpen { bound_pair: BoundPair<T> },
+        RightHalfOpen { bound_pair: BoundPair<T> },
+        UnboundedClosedRight { right: T },
+        UnboundedOpenRight { right: T },
+        UnboundedClosedLeft { left: T },
+        UnboundedOpenLeft { left: T },
+        Singleton { at: T },
+        Unbounded,
+        Empty,
+    }
 }
+
+#[cfg(feature = "serde")]
+mod with_serde {
+    use serde::{Deserialize, Serialize};
+
+    use crate::bound_pair::BoundPair;
+    /// Interval enum capable of general interval representation
+    ///
+    /// Where applicable, using lower bound `a` and upper bound `b`.  An Interval taxonomy was pulled from [proofwiki](https://proofwiki.org/wiki/Definition:Real_Interval_Types).
+    ///
+    /// * Closed -> `[a, b]`
+    /// * Open -> `(a,b)`
+    /// * LeftHalfOpen -> `(a, b]`
+    /// * RightHalfOpen -> `[a, b)`
+    /// * UnboundedClosedRight -> `(-inf, a]`
+    /// * UnboundedOpenRight -> `(-inf, a)`
+    /// * UnboundedClosedLeft -> `[a, inf)`
+    /// * UnboundedOpenLeft -> `(a, inf)`
+    /// * Singeleton -> `[a]`
+    /// * Unbounded -> `(-inf, inf)`
+    /// * Empty
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use intervals_general::bound_pair::BoundPair;
+    /// use intervals_general::interval::Interval;
+    /// # fn main() -> std::result::Result<(), String> {
+    /// let bounds = BoundPair::new(1.0, 2.0).ok_or("invalid BoundPair")?;
+    /// let right_half_open = Interval::RightHalfOpen { bound_pair: bounds }; // [1.0, 2.0)
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+    pub enum Interval<T> {
+        Closed { bound_pair: BoundPair<T> },
+        Open { bound_pair: BoundPair<T> },
+        LeftHalfOpen { bound_pair: BoundPair<T> },
+        RightHalfOpen { bound_pair: BoundPair<T> },
+        UnboundedClosedRight { right: T },
+        UnboundedOpenRight { right: T },
+        UnboundedClosedLeft { left: T },
+        UnboundedOpenLeft { left: T },
+        Singleton { at: T },
+        Unbounded,
+        Empty,
+    }
+}
+
+#[cfg(feature = "serde")]
+pub use with_serde::Interval;
+#[cfg(not(feature = "serde"))]
+pub use without_serde::Interval;
 
 // Internally used to simplify matching functions on Intervals
 enum Bound<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,5 +32,8 @@
 //! 1. No use of of panic, assert
 //! 1. Minimize error handling by design
 //! 1. Make the library hard to use incorrectly
+
 pub mod bound_pair;
 pub mod interval;
+
+pub use interval::Interval;


### PR DESCRIPTION
What's new:
- Add optional `serde` support
- Add a crate-level re-export for `Interval`
- Update dependencies to latest and use rust 2021